### PR TITLE
Example: Use the plugin from plugins.gradle.org

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,32 +1,27 @@
 buildscript {
-    ext.jobDslPluginVersion = '2.0.0'
+    ext.jenkinsJobdslPluginVersion = '2.0.0'
 
     repositories {
-        mavenLocal()
-        jcenter()
         maven {
-            url 'http://repo.jenkins-ci.org/releases/'
+            url 'https://plugins.gradle.org/m2'
         }
     }
 
     dependencies {
-        classpath "com.here.gradle.plugins:gradle-jenkins-jobdsl-plugin:${jobDslPluginVersion}"
+        classpath "com.here.gradle.plugins:gradle-jenkins-jobdsl-plugin:${jenkinsJobdslPluginVersion}"
     }
 }
 
 apply plugin: 'com.here.jobdsl'
 
 repositories {
-    mavenLocal()
-    jcenter()
     maven {
-        url 'http://repo.jenkins-ci.org/releases/'
+        url 'https://plugins.gradle.org/m2'
     }
 }
 
 dependencies {
-    compile localGroovy()
-    compile "com.here.gradle.plugins:gradle-jenkins-jobdsl-plugin:${jobDslPluginVersion}"
+    compile "com.here.gradle.plugins:gradle-jenkins-jobdsl-plugin:${jenkinsJobdslPluginVersion}"
 }
 
 if (properties.buildAgainstPluginProject.toBoolean()) {


### PR DESCRIPTION
Now that the plugin is available on plugins.gradle.org adopt the example
project to use the plugin from there.