### PR TITLE
Fix documentation enableJobs example property logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,9 +241,7 @@ adapted build method of the `CustomJobBuilder` class looks like this:
 Job build(Class<? extends Job> jobClass, @DelegatesTo(Job.class) Closure closure) {
     def job = super.build(jobClass, closure)
     job.with {
-        if (!DslConfig.get('enableJobs')) {
-            disabled()
-        }
+        disabled(!DslConfig.get('enableJobs'))
     }
     return job
 }

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ to add a parameter to enable or disable all jobs:
 ```groovy
 jobdsl {
     configuration = [
-        enableJobs: project.properties['enableJobs'].toBoolean()
+        disableJobs: project.properties['disableJobs']?.toBoolean() ?: false
     ]
 }
 ```
@@ -241,7 +241,7 @@ adapted build method of the `CustomJobBuilder` class looks like this:
 Job build(Class<? extends Job> jobClass, @DelegatesTo(Job.class) Closure closure) {
     def job = super.build(jobClass, closure)
     job.with {
-        disabled(!DslConfig.get('enableJobs'))
+        disabled(DslConfig.get('disableJobs'))
     }
     return job
 }
@@ -254,7 +254,7 @@ Now you can provide a value for the property on the command line to enable or di
 default value for the property in your `gradle.properties` file.
 
 ```bash
-./gradlew -PenableJobs=true dslGenerateXml
+./gradlew -PdisableJobs=true dslGenerateXml
 ```
 
 You can also have server specific configuration in the `build.gradle` file which can be accessed by calling


### PR DESCRIPTION
The logic is flawed in case of the job is already disabled and the value of `enableJobs` is true. In that case the job will not be update to be enabled.