### PR TITLE
dslUpdateJenkins: Add test for UTF-8 characters

### DIFF
--- a/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/UpdateJenkinsTest.groovy
+++ b/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/UpdateJenkinsTest.groovy
@@ -362,4 +362,22 @@ class UpdateJenkinsTest extends AbstractTaskTest {
         gradleSectionOutput(result.output, 'Outdated plugins:') == [ 'gradle' ]
     }
 
+    def 'groovy postbuild step with UTF-8 characters is uploaded correctly'() {
+        given:
+        buildFile << readBuildGradle('updateJenkins/build.gradle')
+        copyResourceToTestDir('updateJenkins/groovy-postbuild-with-utf-8.groovy')
+
+        when:
+        def result = gradleRunner.withArguments('dslUpdateJenkins', jenkinsUrlParam()).build()
+
+        then:
+        result.task(':dslUpdateJenkins').outcome == TaskOutcome.SUCCESS
+        Item item = jenkinsRule.jenkins.getItemByFullName('job')
+        item instanceof FreeStyleProject
+        XMLUnit.compareXML(
+                readResource('updateJenkins/groovy-postbuild-with-utf-8.xml'),
+                item.configFile.asString()
+        ).identical()
+    }
+
 }

--- a/plugin/src/functionalTest/resources/updateJenkins/groovy-postbuild-with-utf-8.groovy
+++ b/plugin/src/functionalTest/resources/updateJenkins/groovy-postbuild-with-utf-8.groovy
@@ -1,0 +1,9 @@
+freeStyleJob('job') {
+        publishers {
+            groovyPostBuild('''\
+                def summary = manager.createSummary('completed.gif')
+                summary.appendText('✔' /* UTF-8 encoded checkmark */, false, false, false, 'green')
+                summary.appendText('✖' /* UTF-8 encoded cross */, false, false, false, 'red')
+                '''.stripIndent())
+        }
+}

--- a/plugin/src/functionalTest/resources/updateJenkins/groovy-postbuild-with-utf-8.xml
+++ b/plugin/src/functionalTest/resources/updateJenkins/groovy-postbuild-with-utf-8.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <actions/>
+    <description/>
+    <keepDependencies>false</keepDependencies>
+    <properties/>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers/>
+    <concurrentBuild>false</concurrentBuild>
+    <builders/>
+    <publishers>
+        <org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder>
+            <script>
+                <script>def summary = manager.createSummary('completed.gif')
+summary.appendText('✔' /* UTF-8 encoded checkmark */, false, false, false, 'green')
+summary.appendText('✖' /* UTF-8 encoded cross */, false, false, false, 'red')
+</script>
+                <sandbox>false</sandbox>
+            </script>
+            <behavior>0</behavior>
+        </org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder>
+    </publishers>
+    <buildWrappers/>
+</project>

--- a/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/RestJobManagement.groovy
+++ b/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/RestJobManagement.groovy
@@ -95,6 +95,7 @@ class RestJobManagement extends AbstractJobManagement implements DeferredJobMana
         viewRequests = []
 
         restClient = new RESTClient(jenkinsUrl)
+        restClient.encoder.charset = 'UTF-8'
         restClient.handler.failure = { it }
 
         if (jenkinsUser != null && jenkinsApiToken != null) {


### PR DESCRIPTION
Add a test to verify that uploading XML job configuration files with UTF-8
characters to Jenkins works correctly.