### PR TITLE
Fix GroovySeedJobBuilder seed script

### DIFF
--- a/plugin/src/main/resources/seedJobGroovyScript.groovy
+++ b/plugin/src/main/resources/seedJobGroovyScript.groovy
@@ -91,6 +91,9 @@ def updateJobs(FilePath filePath, String namePrefix = '') {
             def reader = new BufferedReader(new InputStreamReader(file.read()))
             def parent = findParentItem(fullName)
             def firstLine = reader.readLine()
+            if (firstLine.contains('?xml')) {
+                firstLine = reader.readLine()
+            }
             if (firstLine.contains('View')) {
                 totalViews++
                 def view = parent.getView(name)


### PR DESCRIPTION
In the current version of the plugin, the generated XML files include a declaration at the beginning. This has to be ignored while trying to differentiate between Jobs and Views.

New XML generated files:

```
<?xml version="1.0" encoding="UTF-8"?>
<com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView plugin="build-monitor-plugin@1.12-HERE">
  <name>build-monitor</name>
  <description>Job DSL Docker runner project</description>
  <filterExecutors>false</filterExecutors>
  <filterQueue>false</filterQueue>
  <properties class="hudson.model.View$PropertyList"/>
  <jobNames>
    <comparator class="hudson.util.CaseInsensitiveComparator"/>
    <string>seed-jobdsl</string>
    <string>submit-verify</string>
  </jobNames>
  <jobFilters/>
  <columns/>
  <recurse>true</recurse>
  <title>Job DSL Docker runner project</title>
  <order class="com.smartcodeltd.jenkinsci.plugins.buildmonitor.order.ByName"/>
</com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView>
```

Old XML generated files:

```
<com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView>
    <filterExecutors>false</filterExecutors>
    <filterQueue>false</filterQueue>
    <properties class='hudson.model.View$PropertyList'></properties>
    <jobNames>
        <comparator class='hudson.util.CaseInsensitiveComparator'></comparator>
        <string>seed-jobdsl</string>
        <string>submit-verify</string>
    </jobNames>
    <jobFilters></jobFilters>
    <columns></columns>
    <recurse>true</recurse>
    <order class='com.smartcodeltd.jenkinsci.plugins.buildmonitor.order.ByName'></order>
    <description>Job DSL Docker runner project</description>
    <title>Job DSL Docker runner project</title>
</com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView>
```