### PR TITLE
Add failOnMissingPlugin option to dslGenerateXml task

### DIFF
--- a/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/GenerateXmlTest.groovy
+++ b/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/GenerateXmlTest.groovy
@@ -68,6 +68,21 @@ class GenerateXmlTest extends AbstractTaskTest {
         XMLUnit.compareXML(expectedText, actualText).identical()
     }
 
+    def 'failOnMissingPlugin fails the task if a required plugin is missing'() {
+        given:
+        buildFile << readBuildGradle('generateXml/build-with-missing-plugins.gradle')
+        copyResourceToTestDir('generateXml/folder.groovy')
+
+        when:
+        def result = gradleRunner
+                .withArguments('dslGenerateXml', '--failOnMissingPlugin')
+                .buildAndFail()
+
+        then:
+        result.task(':dslGenerateXml').outcome == TaskOutcome.FAILED
+        result.output.contains("plugin 'cloudbees-folder' needs to be installed")
+    }
+
     def 'job in folder is generated in the right subfolder'() {
         given:
         buildFile << readBuildGradle('generateXml/build.gradle')

--- a/plugin/src/functionalTest/resources/generateXml/build-with-missing-plugins.gradle
+++ b/plugin/src/functionalTest/resources/generateXml/build-with-missing-plugins.gradle
@@ -1,0 +1,11 @@
+buildscript {
+    dependencies {
+        classpath files(CLASSPATH_STRING)
+    }
+}
+
+apply plugin: 'com.here.jobdsl'
+
+dependencies {
+    compile localGroovy()
+}

--- a/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/FilteringJenkinsJobManagement.groovy
+++ b/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/FilteringJenkinsJobManagement.groovy
@@ -11,9 +11,11 @@ class FilteringJenkinsJobManagement extends JenkinsJobManagement {
 
     private final ItemFilter filter
 
-    FilteringJenkinsJobManagement(ItemFilter filter, PrintStream outputLogger, Map<String, ?> envVars, File workspace) {
+    FilteringJenkinsJobManagement(ItemFilter filter, PrintStream outputLogger, Map<String, ?> envVars,
+                                  File workspace, boolean failOnMissingPlugin) {
         super(outputLogger, envVars, workspace)
         this.filter = filter
+        this.failOnMissingPlugin = failOnMissingPlugin
     }
 
     @Override

--- a/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/tasks/GenerateXmlTask.groovy
+++ b/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/tasks/GenerateXmlTask.groovy
@@ -1,14 +1,23 @@
 package com.here.gradle.plugins.jobdsl.tasks
 
+import org.gradle.api.internal.tasks.options.Option
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
 /**
  * Task that calls {@link com.here.gradle.plugins.jobdsl.tasks.runners.GenerateXmlRunner} to generate XML files for
  * all items and views configured in the project.
  */
 class GenerateXmlTask extends AbstractDslTask {
 
+    @Input
+    @Optional
+    boolean failOnMissingPlugin
+
     GenerateXmlTask() {
         super()
         description = 'Generate XML for all jobs.'
+        failOnMissingPlugin = false
     }
 
     @Override
@@ -20,8 +29,14 @@ class GenerateXmlTask extends AbstractDslTask {
     @Override
     Map<String, ?> getProperties() {
         [
-                outputDirectory: "${project.buildDir}/jobdsl/xml"
+                outputDirectory    : "${project.buildDir}/jobdsl/xml",
+                failOnMissingPlugin: failOnMissingPlugin,
         ]
+    }
+
+    @Option(option = 'failOnMissingPlugin', description = 'Fail the task if a required plugin is missing.')
+    void setFailOnMissingPlugin(boolean failOnMissingPlugin) {
+        this.failOnMissingPlugin = failOnMissingPlugin
     }
 
 }

--- a/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/tasks/runners/GenerateXmlRunner.groovy
+++ b/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/tasks/runners/GenerateXmlRunner.groovy
@@ -27,10 +27,11 @@ class GenerateXmlRunner extends AbstractTaskRunner {
 
     @Override
     JobManagement createJobManagement(Jenkins jenkins, ItemFilter filter) {
+        boolean failOnMissingPlugin = runProperties['failOnMissingPlugin'].toBoolean()
         def workspace = Files.createTempDirectory('jobdsl').toFile()
         workspace.deleteOnExit()
 
-        new FilteringJenkinsJobManagement(filter, System.out, [:], workspace)
+        new FilteringJenkinsJobManagement(filter, System.out, [:], workspace, failOnMissingPlugin)
     }
 
     @Override


### PR DESCRIPTION
Similar to the existing option in `dslUpdateJenkins`. This pre-verification would be useful to us as we have several Jenkins instances and we maintain a single plugin set.