### PR TITLE
Inherit folder properties when updating existing items

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -96,10 +96,14 @@ dependencies {
         exclude(module: 'org-netbeans-insane')
     }
 
+    functionalTestCompile 'org.xmlunit:xmlunit-core:2.6.0'
+
     functionalTestCompile 'org.jenkins-ci.plugins:cloudbees-folder:6.4@jar'
+    functionalTestCompile 'org.jenkins-ci.plugins:credentials:2.1.10@jar'
 
     // Plugins to be available for single tests using the @WithPlugin annotation.
     jenkinsPlugins 'org.jenkins-ci.plugins:cloudbees-folder:6.4'
+    jenkinsPlugins 'org.jenkins-ci.plugins:credentials:2.1.10'
     jenkinsPlugins 'org.jenkins-ci.plugins:gradle:1.22' // Old version used to test reporting of outdated plugins.
     jenkinsPlugins 'org.jenkins-ci.plugins:groovy:1.30' // Old version used to test reporting of deprecated plugins.
 }

--- a/plugin/src/functionalTest/resources/updateJenkins/folder-with-credentials.groovy
+++ b/plugin/src/functionalTest/resources/updateJenkins/folder-with-credentials.groovy
@@ -1,0 +1,1 @@
+folder('folder-with-credentials')

--- a/plugin/src/functionalTest/resources/updateJenkins/folder-with-credentials.xml
+++ b/plugin/src/functionalTest/resources/updateJenkins/folder-with-credentials.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?><com.cloudbees.hudson.plugins.folder.Folder>
+  <actions/>
+  <properties>
+    <com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider_-FolderCredentialsProperty>
+      <domainCredentialsMap class="hudson.util.CopyOnWriteMap$Hash">
+        <entry>
+          <com.cloudbees.plugins.credentials.domains.Domain>
+            <specifications/>
+          </com.cloudbees.plugins.credentials.domains.Domain>
+          <java.util.concurrent.CopyOnWriteArrayList>
+            <com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl>
+              <scope>GLOBAL</scope>
+              <id>test-id</id>
+              <description>description</description>
+              <username>test-user</username>
+              <password>{AQAAABAAAAAQzn/mk6p0ZU9It7VEuwlbyBrcDXONDoLU2BJAyvgnYH8=}</password>
+            </com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl>
+          </java.util.concurrent.CopyOnWriteArrayList>
+        </entry>
+      </domainCredentialsMap>
+    </com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider_-FolderCredentialsProperty>
+  </properties>
+  <icon class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/>
+  <folderViews class="com.cloudbees.hudson.plugins.folder.views.DefaultFolderViewHolder">
+    <views>
+      <hudson.model.AllView>
+        <owner reference="../../../.." class="com.cloudbees.hudson.plugins.folder.Folder"/>
+        <name>All</name>
+        <filterExecutors>false</filterExecutors>
+        <filterQueue>false</filterQueue>
+        <properties class="hudson.model.View$PropertyList"/>
+      </hudson.model.AllView>
+    </views>
+    <tabBar class="hudson.views.DefaultViewsTabBar"/>
+    <primaryView>All</primaryView>
+  </folderViews>
+  <healthMetrics>
+    <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric/>
+  </healthMetrics>
+</com.cloudbees.hudson.plugins.folder.Folder>

--- a/plugin/src/main/resources/seedJobGroovyScript.groovy
+++ b/plugin/src/main/resources/seedJobGroovyScript.groovy
@@ -30,11 +30,15 @@ def updateItem(Item item, String name, FilePath file) {
             println "  Item ${name} did not change"
             return
         }
+        def folderCredentialsProviderKey = 'com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider_-FolderCredentialsProperty'
         def existingXmlParsed = new XmlParser().parseText(oldConfig)
-        if (existingXmlParsed.properties != null) {
-            def newXmlParsed = new XmlParser().parseText(newConfig)
-            Node node = existingXmlParsed.properties[0] as Node
-            newXmlParsed.properties[0].replaceNode(node)
+        def newXmlParsed = new XmlParser().parseText(newConfig)
+        if (existingXmlParsed.properties != null &&
+                existingXmlParsed.properties."${folderCredentialsProviderKey}".size() > 0 &&
+                newXmlParsed.properties != null &&
+                newXmlParsed.properties."${folderCredentialsProviderKey}".size() == 0) {
+            def node = existingXmlParsed.properties[0]."${folderCredentialsProviderKey}"[0] as Node
+            newXmlParsed.properties[0].children().add(node)
             inputStream = new ByteArrayInputStream(XmlUtil.serialize(newXmlParsed).getBytes('UTF-8'))
         }
     } catch (Exception e) {


### PR DESCRIPTION
If a folder contains properties, like a credential store, the dslUpdateJenkins task would remove these properties as they're declared in the XML. Storing secrets like this in the JobDSL scripts is not a good alternative, so this change allow us to inherit folder properties when updating existing folder items.