### PR TITLE
Add a test to verify that Gradle dependencies can be used in scripts

### DIFF
--- a/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/GenerateXmlTest.groovy
+++ b/plugin/src/functionalTest/groovy/com/here/gradle/plugins/jobdsl/tasks/GenerateXmlTest.groovy
@@ -378,4 +378,24 @@ class GenerateXmlTest extends AbstractTaskTest {
                         'applicable for argument types')
     }
 
+    def 'dependencies can be used in DSL scripts'() {
+        given:
+        buildFile << readBuildGradle('generateXml/build-with-dependency.gradle')
+        copyResourceToTestDir('generateXml/job-with-dependency.groovy')
+
+        when:
+        def result = gradleRunner
+                .withArguments('dslGenerateXml')
+                .build()
+
+        then:
+        result.task(':dslGenerateXml').outcome == TaskOutcome.SUCCESS
+
+        def generatedFile = new File(testProjectDir.root, 'build/jobdsl/xml/job.xml')
+        generatedFile.file
+        def actualText = generatedFile.getText('UTF-8')
+        def expectedText = readResource('generateXml/job-with-dependency.xml')
+        XMLUnit.compareXML(expectedText, actualText).identical()
+    }
+
 }

--- a/plugin/src/functionalTest/resources/generateXml/build-with-dependency.gradle
+++ b/plugin/src/functionalTest/resources/generateXml/build-with-dependency.gradle
@@ -1,0 +1,12 @@
+buildscript {
+    dependencies {
+        classpath files(CLASSPATH_STRING)
+    }
+}
+
+apply plugin: 'com.here.jobdsl'
+
+dependencies {
+    compile localGroovy()
+    compile 'org.apache.commons:commons-text:1.4'
+}

--- a/plugin/src/functionalTest/resources/generateXml/job-with-dependency.groovy
+++ b/plugin/src/functionalTest/resources/generateXml/job-with-dependency.groovy
@@ -1,0 +1,5 @@
+import org.apache.commons.text.StrBuilder
+
+def builder = new StrBuilder('job')
+
+freeStyleJob(builder.build())

--- a/plugin/src/functionalTest/resources/generateXml/job-with-dependency.xml
+++ b/plugin/src/functionalTest/resources/generateXml/job-with-dependency.xml
@@ -1,0 +1,16 @@
+<project>
+    <actions></actions>
+    <description></description>
+    <keepDependencies>false</keepDependencies>
+    <properties></properties>
+    <scm class='hudson.scm.NullSCM'></scm>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers></triggers>
+    <concurrentBuild>false</concurrentBuild>
+    <builders></builders>
+    <publishers></publishers>
+    <buildWrappers></buildWrappers>
+</project>


### PR DESCRIPTION
Add a test to verify that dependencies added to the "compile" configuration
in Gradle are available in the Jenkins instance that executes the DSL
scripts.