### PR TITLE
Use HTTPS URL for the plugin's vcsUrl

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -208,7 +208,7 @@ publishing {
 // Configuration for publication to the Gradle plugin registry.
 pluginBundle {
     website = 'https://github.com/heremaps/gradle-jenkins-jobdsl-plugin'
-    vcsUrl = 'git@github.com:heremaps/gradle-jenkins-jobdsl-plugin.git'
+    vcsUrl = 'https://github.com/heremaps/gradle-jenkins-jobdsl-plugin.git'
     description = 'A Gradle plugin to manage Jenkins Job DSL scripts.'
 
     plugins {


### PR DESCRIPTION
Otherwise the plugin-publish-plugin fails with "Invalid URI".

Signed-off-by: Martin Nonnenmacher <martin.nonnenmacher@here.com>