### PR TITLE
Add proxy support for the update Jenkins task

### DIFF
--- a/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/RestJobManagement.groovy
+++ b/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/RestJobManagement.groovy
@@ -98,7 +98,7 @@ class RestJobManagement extends AbstractJobManagement implements DeferredJobMana
 
     @SuppressWarnings('ParameterCount')
     RestJobManagement(ItemFilter filter, boolean disablePluginChecks, boolean dryRun, String jenkinsUrl,
-                      String jenkinsUser, String jenkinsApiToken, Jenkins jenkins) {
+                      String jenkinsUser, String jenkinsApiToken, String proxyUrl, Jenkins jenkins) {
         super(System.out)
 
         this.disablePluginChecks = disablePluginChecks
@@ -127,6 +127,10 @@ class RestJobManagement extends AbstractJobManagement implements DeferredJobMana
         restClient = new RESTClient(jenkinsUrl)
         restClient.encoder.charset = 'UTF-8'
         restClient.handler.failure = { it }
+        if (proxyUrl != null && !proxyUrl.isEmpty()) {
+            URI proxyURI = new URI(proxyUrl)
+            restClient.setProxy(proxyURI.host, proxyURI.port, proxyURI.scheme)
+        }
 
         if (jenkinsUser != null && jenkinsApiToken != null) {
             restClient.client.addRequestInterceptor([

--- a/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/ServerDefinition.groovy
+++ b/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/ServerDefinition.groovy
@@ -28,6 +28,7 @@ class ServerDefinition {
     String jenkinsUrl
     String jenkinsUser
     String jenkinsApiToken
+    String proxyUrl
     Map<String, ?> configuration = [:]
 
     ServerDefinition(String name) {

--- a/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/tasks/UpdateJenkinsTask.groovy
+++ b/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/tasks/UpdateJenkinsTask.groovy
@@ -43,6 +43,10 @@ class UpdateJenkinsTask extends AbstractDslTask {
 
     @Input
     @Optional
+    String proxyUrl
+
+    @Input
+    @Optional
     String jenkinsUser
 
     @Input
@@ -76,6 +80,10 @@ class UpdateJenkinsTask extends AbstractDslTask {
             if (jenkinsApiToken == null) {
                 jenkinsApiToken = server.jenkinsApiToken
             }
+
+            if (proxyUrl == null) {
+                proxyUrl = server.proxyUrl
+            }
         }
 
         return [
@@ -83,7 +91,8 @@ class UpdateJenkinsTask extends AbstractDslTask {
                 dryRun             : dryRun,
                 jenkinsUrl         : jenkinsUrl,
                 jenkinsUser        : jenkinsUser,
-                jenkinsApiToken    : jenkinsApiToken
+                jenkinsApiToken    : jenkinsApiToken,
+                proxyUrl           : proxyUrl
         ]
     }
 
@@ -110,6 +119,11 @@ class UpdateJenkinsTask extends AbstractDslTask {
     @Option(option = 'jenkinsApiToken', description = 'Jenkins API token.')
     void setJenkinsApiToken(String jenkinsApiToken) {
         this.jenkinsApiToken = jenkinsApiToken
+    }
+
+    @Option(option = 'proxyUrl', description = 'URL of the HTTP proxy used to communicate with Jenkins.')
+    void setProxyUrl(String proxyUrl) {
+        this.proxyUrl = proxyUrl
     }
 
 }

--- a/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/tasks/runners/UpdateJenkinsRunner.groovy
+++ b/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/tasks/runners/UpdateJenkinsRunner.groovy
@@ -45,8 +45,10 @@ class UpdateJenkinsRunner extends AbstractTaskRunner {
         String jenkinsUrl = runProperties['jenkinsUrl']
         String jenkinsUser = runProperties['jenkinsUser']
         String jenkinsApiToken = runProperties['jenkinsApiToken']
+        String proxyUrl = runProperties['proxyUrl']
 
-        new RestJobManagement(filter, disablePluginChecks, dryRun, jenkinsUrl, jenkinsUser, jenkinsApiToken, jenkins)
+        new RestJobManagement(filter, disablePluginChecks, dryRun, jenkinsUrl,
+                              jenkinsUser, jenkinsApiToken, proxyUrl, jenkins)
     }
 
     @Override


### PR DESCRIPTION
Our Jenkins instance can only be reached through an HTTP proxy, this PR adds proxy support for the update Jenkins task, either in the server configuration or the command line. Authentication is not supported.