### PR TITLE
Add ignore SSL errors option to the update Jenkins task

### DIFF
--- a/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/RestJobManagement.groovy
+++ b/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/RestJobManagement.groovy
@@ -98,7 +98,8 @@ class RestJobManagement extends AbstractJobManagement implements DeferredJobMana
 
     @SuppressWarnings('ParameterCount')
     RestJobManagement(ItemFilter filter, boolean disablePluginChecks, boolean dryRun, String jenkinsUrl,
-                      String jenkinsUser, String jenkinsApiToken, String proxyUrl, Jenkins jenkins) {
+                      String jenkinsUser, String jenkinsApiToken, String proxyUrl, Boolean ignoreSslErrors,
+                      Jenkins jenkins) {
         super(System.out)
 
         this.disablePluginChecks = disablePluginChecks
@@ -130,6 +131,9 @@ class RestJobManagement extends AbstractJobManagement implements DeferredJobMana
         if (proxyUrl != null && !proxyUrl.isEmpty()) {
             URI proxyURI = new URI(proxyUrl)
             restClient.setProxy(proxyURI.host, proxyURI.port, proxyURI.scheme)
+        }
+        if (ignoreSslErrors) {
+            restClient.ignoreSSLIssues()
         }
 
         if (jenkinsUser != null && jenkinsApiToken != null) {

--- a/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/ServerDefinition.groovy
+++ b/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/ServerDefinition.groovy
@@ -29,6 +29,7 @@ class ServerDefinition {
     String jenkinsUser
     String jenkinsApiToken
     String proxyUrl
+    Boolean ignoreSslErrors
     Map<String, ?> configuration = [:]
 
     ServerDefinition(String name) {

--- a/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/tasks/UpdateJenkinsTask.groovy
+++ b/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/tasks/UpdateJenkinsTask.groovy
@@ -47,6 +47,10 @@ class UpdateJenkinsTask extends AbstractDslTask {
 
     @Input
     @Optional
+    Boolean ignoreSslErrors
+
+    @Input
+    @Optional
     String jenkinsUser
 
     @Input
@@ -84,6 +88,10 @@ class UpdateJenkinsTask extends AbstractDslTask {
             if (proxyUrl == null) {
                 proxyUrl = server.proxyUrl
             }
+
+            if (ignoreSslErrors == null) {
+                ignoreSslErrors = server.ignoreSslErrors
+            }
         }
 
         return [
@@ -92,7 +100,8 @@ class UpdateJenkinsTask extends AbstractDslTask {
                 jenkinsUrl         : jenkinsUrl,
                 jenkinsUser        : jenkinsUser,
                 jenkinsApiToken    : jenkinsApiToken,
-                proxyUrl           : proxyUrl
+                proxyUrl           : proxyUrl,
+                ignoreSslErrors    : ignoreSslErrors
         ]
     }
 
@@ -124,6 +133,11 @@ class UpdateJenkinsTask extends AbstractDslTask {
     @Option(option = 'proxyUrl', description = 'URL of the HTTP proxy used to communicate with Jenkins.')
     void setProxyUrl(String proxyUrl) {
         this.proxyUrl = proxyUrl
+    }
+
+    @Option(option = 'ignoreSslErrors', description = 'Used to disable SSL error checking')
+    void setIgnoreSslErrors(Boolean ignoreSslErrors) {
+        this.ignoreSslErrors = ignoreSslErrors
     }
 
 }

--- a/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/tasks/runners/UpdateJenkinsRunner.groovy
+++ b/plugin/src/main/groovy/com/here/gradle/plugins/jobdsl/tasks/runners/UpdateJenkinsRunner.groovy
@@ -46,9 +46,10 @@ class UpdateJenkinsRunner extends AbstractTaskRunner {
         String jenkinsUser = runProperties['jenkinsUser']
         String jenkinsApiToken = runProperties['jenkinsApiToken']
         String proxyUrl = runProperties['proxyUrl']
+        Boolean ignoreSslErrors = runProperties['ignoreSslErrors']
 
         new RestJobManagement(filter, disablePluginChecks, dryRun, jenkinsUrl,
-                              jenkinsUser, jenkinsApiToken, proxyUrl, jenkins)
+                              jenkinsUser, jenkinsApiToken, proxyUrl, ignoreSslErrors, jenkins)
     }
 
     @Override


### PR DESCRIPTION
This option can be useful to us while we are changing SSL certificates / DNS settings in an existing Jenkins instance.