### PR TITLE
README: Update the Travis status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 | :---- | :------ |
 [ ![Linux build status][1]][2] | [![Windows build status][3]][4] |
 
-[1]: https://travis-ci.org/heremaps/gradle-jenkins-jobdsl-plugin.svg?branch=master
-[2]: https://travis-ci.org/heremaps/gradle-jenkins-jobdsl-plugin
+[1]: https://travis-ci.com/heremaps/gradle-jenkins-jobdsl-plugin.svg?branch=master
+[2]: https://travis-ci.com/heremaps/gradle-jenkins-jobdsl-plugin
 [3]: https://ci.appveyor.com/api/projects/status/37g184qui7ityfw2/branch/master?svg=true
 [4]: https://ci.appveyor.com/project/heremaps/gradle-jenkins-jobdsl-plugin/branch/master
 


### PR DESCRIPTION
CI was moved from travis.org to travis.com.